### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Also, read how it was done in [our blog] (https://yalantis.com/blog/how-we-devel
 
     ~~~
     dependencies {
-        compile 'com.github.Yalantis:GuillotineMenu-Android:1.2'
+        implementation 'com.github.Yalantis:GuillotineMenu-Android:1.2'
     }
     ~~~
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.